### PR TITLE
fix: fix wbtc decimals

### DIFF
--- a/versioned_docs/version-1.3-rc1(WIP)/tokens.md
+++ b/versioned_docs/version-1.3-rc1(WIP)/tokens.md
@@ -28,7 +28,7 @@ Below you can find ERC20 token addresses on Godwoken networks.
 * USDC (via Forcebridge from ETH): 0x630AcC0A29E325ce022563Df69ba7E25Eeb1e184
 * USDT (via Forcebridge from ETH): 0x10A86c9C8CbE7cf2849bfCb0EaBE39b3bFEc91D4
 * DAI (via Forcebridge from ETH): 0xA2370D7aFFf03e1E2FB77b28Fb65532636e0cB61
-* WBTC (via Forcebridge from ETH): 0x6935a6841bbBDb7430acc1906188301F3044FB76
+* WBTC (via Forcebridge from ETH): 0x744f7bc43F8492A688AFEe373dfd41EAf5C6000C
 * USDC (from [https://testnet.bridge.godwoken.io](https://testnet.bridge.godwoken.io)): 0x30D4B957139785B979aF5312d71505809dc563ed
 * dCKB (from [https://aggron.nexisdao.com/dckb](https://aggron.nexisdao.com/dckb)): 0x7e54f7324902B72334827F40f613116F06a88845
 * BNB (via Forcebridge from BSC): 0xFB60eBF591bc5e363A24b67518339F0015Ad02eE


### PR DESCRIPTION
Previously WBTC on testnet was using wrong decimals (18 instead of 8). Force Bridge team has fixed the problem, but the ERC20 token on Godwoken had to be redeployed. In this pull request I'm adding the new, working address for WBTC.